### PR TITLE
Export `Jenkins` class

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,11 +16,11 @@
 
 export {
     jenkins,
+    Jenkins,
     JenkinsJobParameters,
     JenkinsRegistration,
     JenkinsJobDefinition,
     JenkinsJobName,
-
     JenkinsProgressReporter,
     JenkinsProgressTests,
 } from "./lib/goal/Jenkins";

--- a/lib/goal/Jenkins.ts
+++ b/lib/goal/Jenkins.ts
@@ -114,7 +114,7 @@ export function jenkins(goalDetails: string | FulfillableGoalDetails, registrati
     });
 }
 
-class Jenkins extends FulfillableGoalWithRegistrations<JenkinsRegistration> {
+export class Jenkins extends FulfillableGoalWithRegistrations<JenkinsRegistration> {
 
     constructor(private readonly goalDefinition: GoalDefinition,
                 ...dependsOn: Goal[]) {


### PR DESCRIPTION
Export the `Jenkins` class returned by `jenkins` to allow greater compatibility with data driven SDM definitions.

Currently I'm inferring the type via `type Jenkins = ReturnType<typeof jenkinsRun>;`